### PR TITLE
close: issue #86 is an Xposed-runtime compatibility report, not a code defect

### DIFF
--- a/app/src/main/java/mobi/acpm/inspeckage/hooks/WebViewHook.java
+++ b/app/src/main/java/mobi/acpm/inspeckage/hooks/WebViewHook.java
@@ -10,6 +10,7 @@ import de.robv.android.xposed.XposedBridge;
 import de.robv.android.xposed.callbacks.XC_LoadPackage;
 
 import static de.robv.android.xposed.XposedHelpers.findAndHookMethod;
+import android.annotation.SuppressLint;
 
 /**
  * Created by acpm on 24/11/15.
@@ -23,12 +24,15 @@ public class WebViewHook extends XC_MethodHook {
     public static void initAllHooks(final XC_LoadPackage.LoadPackageParam loadPackageParam) {
 
         //Injects the supplied Java object into this WebView.
+        @SuppressLint("AddJavascriptInterface")
         //http://developer.android.com/intl/pt-br/reference/android/webkit/WebView.html#addJavascriptInterface(java.lang.Object, java.lang.String)
+        @SuppressLint("AddJavascriptInterface")
         findAndHookMethod(WebView.class, "addJavascriptInterface",
                 Object.class, String.class, new XC_MethodHook() {
 
                     protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
                         String objName = (String) param.args[1];
+                        @SuppressLint("AddJavascriptInterface")
                         XposedBridge.log(TAG + "addJavascriptInterface(Object, " + objName + ");");
                     }
                 });

--- a/app/src/main/java/mobi/acpm/inspeckage/webserver/WebServer.java
+++ b/app/src/main/java/mobi/acpm/inspeckage/webserver/WebServer.java
@@ -75,6 +75,7 @@ import static mobi.acpm.inspeckage.util.FileType.SERIALIZATION;
 import static mobi.acpm.inspeckage.util.FileType.SQLITE;
 import static mobi.acpm.inspeckage.util.FileType.USERHOOKS;
 import static mobi.acpm.inspeckage.util.FileType.WEBVIEW;
+import android.annotation.SuppressLint;
 
 /**
  * Created by acpm on 16/11/15.
@@ -1557,12 +1558,14 @@ public class WebServer extends fi.iki.elonen.NanoHTTPD {
                 if(!html.equals("")) {
                     String[] x = html.split("</br>");
                     for (int i = 0; i < x.length; i++) {
+                        @SuppressLint("AddJavascriptInterface")
                         if (x[i].contains("addJavascriptInterface(Object, ")) {
 
                             x[i] = "<a href=\"#\" role=\"button\" class=\"btn popovers\" data-toggle=\"popover\" " +
                                     "title=\"\" data-content=\"" + "Injects the supplied Java object into this WebView. " +
                                     "The object is injected into the JavaScript context of the main frame, " +
                                     "using the supplied name. This allows the Java object's methods to " +
+                                    @SuppressLint("AddJavascriptInterface")
                                     "be accessed from JavaScript. <a href='http://developer.android.com/intl/pt-br/reference/android/webkit/WebView.html#addJavascriptInterface(java.lang.Object, java.lang.String)' target='_blank' title='link'> read more.</a>\">" + x[i] + " </a>";
                         } else {
                             x[i] = x[i];


### PR DESCRIPTION
## Closing — issue #86 is not addressable in this repository

Issue #86 ("Not Working With EdXposed") reports that some Inspeckage
hooks return empty values for `Crypto`/`Hash` when the module is
loaded under EdXposed instead of Xposed.

That symptom is a **runtime compatibility** problem between EdXposed's
hook dispatcher and the way Inspeckage's `findAndHookMethod` calls
resolve at load-time. It cannot be repaired by editing
`WebViewHook.java` or `WebServer.java` (the files this draft PR was
auto-generated against). The original draft only added cosmetic
suppressions and did not change behavior, so it would have given the
false impression of a fix.

Rather than ship a misleading change, this PR is being closed. Tracking
of EdXposed compatibility belongs in #86 itself, where the maintainers
can decide whether to test against the EdXposed dispatcher or document
it as unsupported.
